### PR TITLE
v4.3.0

### DIFF
--- a/companion/HELP.md
+++ b/companion/HELP.md
@@ -1,12 +1,12 @@
-Supports all versions up to **4.2b9**.
+Supports all versions up to **4.3b3**.
 You can select the appropriate version, and the module will automatically adjust the set of commands according to your choice.
 
 ---
 
-**🔧 Available Commands (for Playdeck 4.1b16; version dependent)**
+**🔧 Available Commands (for Playdeck 4.3b3; version dependent)**
 
 - **CONTROL**:
-  CUE/PLAY/FADE-IN by number/list/UID/flex; CUE/PLAY Next; SWITCH CHANNEL; PAUSE/STOP; POSITION; POSITION SAVE/RECALL; FADE EDIT; SELECT Previous/Next Clip; MARK Next Clip; ACTIVATE/DISABLE Clip; LOOP/UNLOOP Clip
+  CUE/PLAY/FADE-IN by number/list/UID/flex; CUE/PLAY Next; SWITCH CHANNEL; PAUSE/STOP; POSITION; POSITION SAVE/RECALL; FADE EDIT; SELECT Previous/Next Clip; MARK Next Clip; ACTIVATE/DISABLE Clip; LOOP/UNLOOP Clip; POSITION MARKER
 
 - **ASSETS**:
   LOAD, APPEND Project
@@ -46,7 +46,7 @@ You can select the appropriate version, and the module will automatically adjust
 **Current channel state**
 
 - **Channel**: 1–8
-- **State**: `STOP`, `PAUSE`, `PLAY`, `CUE`
+- **State**: `STOP`, `PAUSE`, `PLAY`, `CUE`, `END`
 - **Block Number/Name**: `0` = any
 - **Clip Number/Name**: `0` = any
 - **Item ID**

--- a/companion/manifest.json
+++ b/companion/manifest.json
@@ -3,7 +3,7 @@
 	"name": "Playdeck (Video Playout Software)",
 	"shortname": "Playdeck",
 	"description": "Playdeck (Video Playout Software)",
-	"version": "4.2.9",
+	"version": "4.3.0",
 	"license": "MIT",
 	"repository": "git+https://github.com/bitfocus/companion-module-joy-playdeck.git",
 	"bugs": "https://github.com/bitfocus/companion-module-joy-playdeck/issues",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "joy-playdeck",
-	"version": "4.2.9",
+	"version": "4.3.0",
 	"description": "Playdeck (Video Playout Software)",
 	"main": "dist/index.js",
 	"scripts": {

--- a/src/core/actions/Commands/Items/V3/PlaydeckComandsV3.ts
+++ b/src/core/actions/Commands/Items/V3/PlaydeckComandsV3.ts
@@ -96,7 +96,7 @@ export class PlaydeckCommandsV3 extends PlaydeckCommands {
 				label: `${arg}:`,
 				required: true,
 				regex: regex,
-				useVariables: true,
+				useVariables: { local: true },
 				tooltip: tooltip,
 			}
 		}

--- a/src/core/actions/Commands/Items/V4/PlaydeckComandsV4.ts
+++ b/src/core/actions/Commands/Items/V4/PlaydeckComandsV4.ts
@@ -74,7 +74,7 @@ export class PlaydeckCommandsV4 extends PlaydeckCommands {
 				label: `${arg}:`,
 				required: true,
 				regex: regex,
-				useVariables: true,
+				useVariables: { local: true },
 				tooltip: tooltip,
 			}
 		}

--- a/src/core/actions/Commands/Items/V4/PlaydeckComandsV4.ts
+++ b/src/core/actions/Commands/Items/V4/PlaydeckComandsV4.ts
@@ -22,6 +22,7 @@ export type argNamesV4 =
 	| 'INPUT'
 	| 'COMMAND'
 	| 'TIME'
+	| 'MARKER'
 export interface PlaydeckCommandV4 extends PlaydeckCommand {
 	arg1?: argNamesV4
 	arg2?: argNamesV4

--- a/src/core/actions/Commands/Items/V4/PlayoutCommands/PlayoutCommands.ts
+++ b/src/core/actions/Commands/Items/V4/PlayoutCommands/PlayoutCommands.ts
@@ -50,7 +50,7 @@ function playoutAll(): PlaydeckCommandV4[] {
 	all.push(unloop)
 	all.push(mute)
 	all.push(unmute)
-
+	all.push(positionmarker)
 	return all
 }
 
@@ -257,7 +257,7 @@ const marknext: PlaydeckCommandV4 = {
 const activate: PlaydeckCommandV4 = {
 	version: '4.2b9',
 	deprecated: null,
-	commandName: `CONTROL - ACTIVATE Clip `,
+	commandName: `CONTROL - ACTIVATE Clip`,
 	command: `activate`,
 	description: `Sets the Clip as active for Playout (same as Checkmark). ${dontProvideMessage}`,
 	arg1: 'CHANNEL',
@@ -268,7 +268,7 @@ const activate: PlaydeckCommandV4 = {
 const disable: PlaydeckCommandV4 = {
 	version: '4.2b9',
 	deprecated: null,
-	commandName: `CONTROL - DISABLE Clip `,
+	commandName: `CONTROL - DISABLE Clip`,
 	command: `disable`,
 	description: `Sets the Clip as inactive for Playout (same as Checkmark). ${dontProvideMessage}`,
 	arg1: 'CHANNEL',
@@ -279,7 +279,7 @@ const disable: PlaydeckCommandV4 = {
 const loop: PlaydeckCommandV4 = {
 	version: '4.2b9',
 	deprecated: null,
-	commandName: `CONTROL - LOOP Clip `,
+	commandName: `CONTROL - LOOP Clip`,
 	command: `loop`,
 	description: `Sets the Clip for infinite looping. ${dontProvideMessage}`,
 	arg1: 'CHANNEL',
@@ -290,7 +290,7 @@ const loop: PlaydeckCommandV4 = {
 const unloop: PlaydeckCommandV4 = {
 	version: '4.2b9',
 	deprecated: null,
-	commandName: `CONTROL - UNLOOP Clip `,
+	commandName: `CONTROL - UNLOOP Clip`,
 	command: `unloop`,
 	description: `Sets the Clip for not looping. ${dontProvideMessage}`,
 	arg1: 'CHANNEL',
@@ -301,7 +301,7 @@ const unloop: PlaydeckCommandV4 = {
 const mute: PlaydeckCommandV4 = {
 	version: '4.2b9',
 	deprecated: null,
-	commandName: `CONTROL - MUTE Clip `,
+	commandName: `CONTROL - MUTE Clip`,
 	command: `mute`,
 	description: `Sets the Clip as muted. ${dontProvideMessage}`,
 	arg1: 'CHANNEL',
@@ -312,11 +312,21 @@ const mute: PlaydeckCommandV4 = {
 const unmute: PlaydeckCommandV4 = {
 	version: '4.2b9',
 	deprecated: null,
-	commandName: `CONTROL - UNMUTE Clip `,
+	commandName: `CONTROL - UNMUTE Clip`,
 	command: `unmute`,
 	description: `Sets the Clip as not muted. ${dontProvideMessage}`,
 	arg1: 'CHANNEL',
 	arg2: 'BLOCK',
 	arg3: 'CLIP',
+}
+
+const positionmarker: PlaydeckCommandV4 = {
+	version: '4.3b3',
+	deprecated: null,
+	commandName: `CONTROL - POSITION MARKER`,
+	command: `positionmarker`,
+	description: `Jump to the designated Marker Name within the current playing Clip`,
+	arg1: 'CHANNEL',
+	arg2: 'MARKER',
 }
 export const PlayoutCommands: PlaydeckCommandV4[] = [...playoutAll()]

--- a/src/core/actions/Commands/Items/V4/PlayoutCommands/PlayoutCommands.ts
+++ b/src/core/actions/Commands/Items/V4/PlayoutCommands/PlayoutCommands.ts
@@ -60,7 +60,7 @@ function playout(command: PlayoutCommand): PlaydeckCommandV4 {
 		deprecated: null,
 		commandName: `CONTROL - ${playoutCommands[command]}`,
 		command: `${command}`,
-		description: `${playoutCommands[command]} the Clip in the Channel. ${dontProvideMessage}. Will skip inactive Clips.`,
+		description: `${playoutCommands[command]} the Clip in the Channel. ${dontProvideMessage} Will skip inactive Clips.`,
 		arg1: 'CHANNEL',
 		arg2: 'BLOCK',
 		arg3: 'CLIP',

--- a/src/core/actions/PlaydeckActions.ts
+++ b/src/core/actions/PlaydeckActions.ts
@@ -1,4 +1,10 @@
-import { CompanionActionDefinitions, CompanionActionEvent, InputValue, LogLevel } from '@companion-module/base'
+import {
+	CompanionActionDefinitions,
+	CompanionActionEvent,
+	CompanionFeedbackContext,
+	InputValue,
+	LogLevel,
+} from '@companion-module/base'
 import { PlaydeckInstance } from '../../index.js'
 import { PlaydeckUtils } from '../../utils/PlaydeckUtils.js'
 import { PlaydeckCommandsFactory } from './Commands/Items/PlaydeckComandsFactory.js'
@@ -30,8 +36,8 @@ export class PlaydeckActions {
 			const commanndID = playdeckCommand.command
 			result[commanndID] = {
 				name: playdeckCommand.commandName,
-				callback: async (action) => {
-					await this.#doAction(action)
+				callback: async (action, ctx) => {
+					await this.#doAction(action, ctx)
 				},
 				options: commands.getOptions(playdeckCommand),
 				description: playdeckCommand.description,
@@ -39,12 +45,12 @@ export class PlaydeckActions {
 		})
 		return result
 	}
-	async #doAction(action: PlaydeckAction) {
+	async #doAction(action: PlaydeckAction, ctx: CompanionFeedbackContext) {
 		const outgoingConnection = this.#instance.connectionManager?.outgoing
 		let { arg1, arg2, arg3 } = action.options
-		if (arg1 !== undefined) arg1 = await this.#instance.parseVariablesInString(arg1.toString())
-		if (arg2 !== undefined) arg2 = await this.#instance.parseVariablesInString(arg2.toString())
-		if (arg3 !== undefined) arg3 = await this.#instance.parseVariablesInString(arg3.toString())
+		if (arg1 !== undefined) arg1 = await ctx.parseVariablesInString(arg1.toString())
+		if (arg2 !== undefined) arg2 = await ctx.parseVariablesInString(arg2.toString())
+		if (arg3 !== undefined) arg3 = await ctx.parseVariablesInString(arg3.toString())
 		const command = this.#makeRCCommand(action.actionId, [arg1, arg2, arg3])
 		if (outgoingConnection) {
 			if (command !== ``) {

--- a/src/core/data/PlaydeckProjectManager/V4/PlaydectDataV4.ts
+++ b/src/core/data/PlaydeckProjectManager/V4/PlaydectDataV4.ts
@@ -64,7 +64,7 @@ export class PlaydeckDataV4
 			for (const block of channel.block) {
 				blocks.set(block.id, block)
 				channels.set(block.id, channelNumber)
-				if (block.clip === undefined) return
+				if (block.clip === undefined) continue
 				for (const clip of block.clip) {
 					clips.set(clip.id, clip)
 					channels.set(clip.id, channelNumber)

--- a/src/core/data/PlaydeckProjectManager/V4/PlaydectDataV4.ts
+++ b/src/core/data/PlaydeckProjectManager/V4/PlaydectDataV4.ts
@@ -66,6 +66,7 @@ export class PlaydeckDataV4
 				channels.set(block.id, channelNumber)
 				if (block.clip === undefined) continue
 				for (const clip of block.clip) {
+					clip.parentID = block.id
 					clips.set(clip.id, clip)
 					channels.set(clip.id, channelNumber)
 				}
@@ -208,6 +209,8 @@ export class PlaydeckBlockData extends PlaydeckItemData {
 }
 
 export class PlaydeckClipData extends PlaydeckItemData {
+	/** UID of parent BLOCK for lookup table */
+	parentID?: number
 	itemType: keyof typeof ItemType
 	fileName?: string
 	fileSize?: string

--- a/src/core/data/PlaydeckProjectManager/V4/PlaydectDataV4.ts
+++ b/src/core/data/PlaydeckProjectManager/V4/PlaydectDataV4.ts
@@ -29,6 +29,12 @@ export class PlaydeckDataV4
 	#rawData: PlaydeckDataMessage | null = null
 	constructor(projectDataObject: object) {
 		this.#rawData = projectDataObject as PlaydeckDataMessage
+		if (this.#rawData === null) return
+		this.#common = this.#getCommon()
+		this.#channel = this.#getChannel()
+		if (this.#common === null) return
+		if (this.#channel === null) return
+		this.#buildLookup()
 	}
 	/** This function helps to ident parent channel for ID */
 	getChannelByID(id: number): number | null {
@@ -43,11 +49,8 @@ export class PlaydeckDataV4
 	}
 	getValues(): PlaydeckProjectDataV4 | null {
 		if (this.#rawData === null) return null
-		this.#common = this.#getCommon()
-		this.#channel = this.#getChannel()
 		if (this.#common === null) return null
 		if (this.#channel === null) return null
-		this.#buildLookup()
 		return {
 			common: this.#common,
 			channel: this.#channel,

--- a/src/core/presets/Items/V4/PlaydeckPresetsDefinitionsV416.ts
+++ b/src/core/presets/Items/V4/PlaydeckPresetsDefinitionsV416.ts
@@ -20,7 +20,7 @@ export class PlaydeckPresetsDefinitionsV416 implements PlaydeckPresetsDefinition
 		if (commands === undefined) return
 		this.#commands = commands
 		this.#instance = instance
-		console.log(this.#instance?.label) // USE IT TO GET VARIABLES IN FEEDBACK
+		// console.log(this.#instance?.label) // USE IT TO GET VARIABLES IN FEEDBACK
 		this.#init()
 	}
 	getDefinitions(): CompanionPresetDefinitions {

--- a/src/core/state/Feedbacks/Items/V3/PlaydeckFeedbacksItemsV3.ts
+++ b/src/core/state/Feedbacks/Items/V3/PlaydeckFeedbacksItemsV3.ts
@@ -133,7 +133,7 @@ const utils = {
 				label: `${source} Number/Name (0 for any)`,
 				id: `${source.toLowerCase()}`,
 				default: `0`,
-				useVariables: true,
+				useVariables: { local: true },
 			}
 		},
 	},

--- a/src/core/state/Feedbacks/Items/V4/PlaydeckFeebacksItemsV4.ts
+++ b/src/core/state/Feedbacks/Items/V4/PlaydeckFeebacksItemsV4.ts
@@ -2,6 +2,7 @@ import { combineRgb, CompanionFeedbackDefinitions, CompanionOptionValues, InputV
 import { PlaydeckState } from '../../../../../core/state/PlaydeckState.js'
 import { PlaybackState } from '../../../../../utils/PlaydeckUtils.js'
 import { PlaydeckValuesV4 } from '../../../../data/PlaydeckStatusManager/Versions/V4/v40b00/PlaydeckStatusV4.js'
+import { Events } from '../../../../../core/data/PlaydeckEvents.js'
 
 export const PlaydeckFeedbacksDefinitionsV4 = (state: PlaydeckStateV4): CompanionFeedbackDefinitions => {
 	return {
@@ -24,6 +25,7 @@ export const PlaydeckFeedbacksDefinitionsV4 = (state: PlaydeckStateV4): Companio
 						{ id: PlaybackState.Pause, label: 'PAUSE' },
 						{ id: PlaybackState.Stop, label: 'STOP' },
 						{ id: PlaybackState.Cue, label: 'CUE' },
+						{ id: Events.End, label: 'END' },
 					],
 				},
 				{
@@ -118,14 +120,21 @@ export const PlaydeckFeedbacksDefinitionsV4 = (state: PlaydeckStateV4): Companio
 									if (byID) {
 										const IDState = byID[ID]
 										if (IDState) {
-											isState = String(IDState) === String(fState)
-											return isState
+											if (fState !== Events.End) {
+												isState = String(IDState.state) === String(fState)
+												return isState
+											}
+											return IDState.isEnd
 										}
 									}
 								}
 							} else {
 								if (fState !== undefined) {
-									isState = String(lastChannelState.state) === String(fState)
+									if (fState !== Events.End) {
+										isState = String(lastChannelState.state) === String(fState)
+									} else {
+										isState = lastChannelState.isEnd
+									}
 								}
 								if (fBlock !== undefined) {
 									isBlock = lastChannelBlock.indexOf(String(fBlock)) > -1
@@ -200,7 +209,7 @@ export interface CheckStateOptionValues extends CompanionOptionValues {
 	isChanString: boolean
 	channelNum: number
 	channelString: InputValue
-	state: PlaybackState
+	state: PlaybackState | Events
 	block: InputValue
 	clip: InputValue
 	item: number

--- a/src/core/state/Feedbacks/Items/V4/PlaydeckFeebacksItemsV4.ts
+++ b/src/core/state/Feedbacks/Items/V4/PlaydeckFeebacksItemsV4.ts
@@ -124,7 +124,7 @@ export const PlaydeckFeedbacksDefinitionsV4 = (state: PlaydeckStateV4): Companio
 												isState = String(IDState.state) === String(fState)
 												return isState
 											}
-											return IDState.isEnd
+											return IDState.isEnd ?? false
 										}
 									}
 								}
@@ -133,7 +133,7 @@ export const PlaydeckFeedbacksDefinitionsV4 = (state: PlaydeckStateV4): Companio
 									if (fState !== Events.End) {
 										isState = String(lastChannelState.state) === String(fState)
 									} else {
-										isState = lastChannelState.isEnd
+										isState = lastChannelState.isEnd ?? false
 									}
 								}
 								if (fBlock !== undefined) {

--- a/src/core/state/Feedbacks/Items/V4/PlaydeckFeebacksItemsV4.ts
+++ b/src/core/state/Feedbacks/Items/V4/PlaydeckFeebacksItemsV4.ts
@@ -53,7 +53,7 @@ export const PlaydeckFeedbacksDefinitionsV4 = (state: PlaydeckStateV4): Companio
 					label: `Channel`,
 					id: `channelString`,
 					default: `0`,
-					useVariables: true,
+					useVariables: { local: true },
 					isVisible: (opt) => opt.isChanString === true && opt.isUID === false,
 				},
 
@@ -62,7 +62,7 @@ export const PlaydeckFeedbacksDefinitionsV4 = (state: PlaydeckStateV4): Companio
 					label: `Block Number/Name`,
 					id: `block`,
 					default: ``,
-					useVariables: true,
+					useVariables: { local: true },
 					isVisible: (opt) => opt.isUID === false,
 				},
 				{
@@ -70,7 +70,7 @@ export const PlaydeckFeedbacksDefinitionsV4 = (state: PlaydeckStateV4): Companio
 					label: `Clip Number/Name (0 for any)`,
 					id: `clip`,
 					default: `0`,
-					useVariables: true,
+					useVariables: { local: true },
 					isVisible: (opt) => opt.isUID === false,
 				},
 
@@ -79,7 +79,7 @@ export const PlaydeckFeedbacksDefinitionsV4 = (state: PlaydeckStateV4): Companio
 					label: `Item UID (0 for any)`,
 					id: `item`,
 					default: `0`,
-					useVariables: true,
+					useVariables: { local: true },
 					isVisible: (opt) => opt.isUID === true,
 				},
 			],

--- a/src/core/state/Feedbacks/Items/V4/PlaydeckFeebacksItemsV41b16.ts
+++ b/src/core/state/Feedbacks/Items/V4/PlaydeckFeebacksItemsV41b16.ts
@@ -55,7 +55,7 @@ export const PlaydeckFeedbacksDefinitionsV41b16 = (state: PlaydeckStateV41b16): 
 						label: `Object Number`,
 						id: `objectNumberString`,
 						default: `1`,
-						useVariables: true,
+						useVariables: { local: true },
 						isVisible: (opt) => opt.isNumberString === true,
 					},
 				],

--- a/src/core/state/PlaydeckState.ts
+++ b/src/core/state/PlaydeckState.ts
@@ -134,7 +134,6 @@ export class PlaydeckState {
 				currentChannelState.isEnd = currentEvent === Events.End
 			}
 
-			console.log(currentChannelState.isEnd, currentEvent)
 			if (event.blockName) {
 				currentChannelState.blockName = event.blockName
 			}

--- a/src/core/state/PlaydeckState.ts
+++ b/src/core/state/PlaydeckState.ts
@@ -124,9 +124,17 @@ export class PlaydeckState {
 			let asset
 
 			if (channels[channelNumber] === undefined) {
-				channels[channelNumber] = {}
+				channels[channelNumber] = {
+					isEnd: false,
+				}
 			}
 			const currentChannelState = channels[channelNumber]
+
+			if (currentEvent !== Events.Pause && currentEvent !== Events.Stop) {
+				currentChannelState.isEnd = currentEvent === Events.End
+			}
+
+			console.log(currentChannelState.isEnd, currentEvent)
 			if (event.blockName) {
 				currentChannelState.blockName = event.blockName
 			}
@@ -173,7 +181,15 @@ export class PlaydeckState {
 			}
 			const byID = this.lastState.byID
 
-			byID[ID] = currentEvent
+			if (byID[ID] === undefined) {
+				byID[ID] = {
+					isEnd: false,
+				}
+			}
+			byID[ID].state = currentEvent
+			if (currentEvent !== Events.Pause && currentEvent !== Events.Stop) {
+				byID[ID].isEnd = currentEvent === Events.End
+			}
 		}
 	}
 	#log(level: LogLevel, message: string) {
@@ -184,14 +200,17 @@ export class PlaydeckState {
 export interface PlaydeckLastState {
 	playlist?: Record<number, PlaydeckChannelState>
 	channel?: Record<number, PlaydeckChannelState>
-	byID?: Record<PlaydeckUID, Events>
+	byID?: Record<PlaydeckUID, LastState>
 	recording?: Events
 }
 
 type PlaydeckUID = number
 
-interface PlaydeckChannelState {
+interface LastState {
+	isEnd?: boolean
 	state?: Events
+}
+interface PlaydeckChannelState extends LastState {
 	clipName?: string
 	clipNumber?: number
 	blockName?: string

--- a/src/core/state/Variables/Items/PlaydeckVariableItems.ts
+++ b/src/core/state/Variables/Items/PlaydeckVariableItems.ts
@@ -11,7 +11,7 @@ export const variableItems: PlaydeckVariableItem[] = [...variableItemsV3, ...var
 
 /** null returns if need to ignore results, undefined if need to delete from variables */
 export interface PlaydeckVariableItem {
-	getVariableDefinition: (channel?: number) => CompanionVariableDefinition | null
+	getVariableDefinition: (channel?: number, block?: number) => CompanionVariableDefinition | null
 	getCurrentValue?: (
 		current: PlaydeckStatusValues<any, any, any>,
 		channel?: number,
@@ -19,9 +19,11 @@ export interface PlaydeckVariableItem {
 	getFromData?: (
 		data: { data: PlaydeckDataInterface<any, any, any, any>; current?: PlaydeckStatusValues<any, any> },
 		channel?: number,
+		block?: number,
 	) => CompanionVariableValue | undefined | null
 	getValueFromEvent?: (event: PlaydeckEvent, channel?: number) => CompanionVariableValue | undefined | null
 	channel?: boolean | number
+	block?: boolean | number
 	version: Version | null
 	deprecated: Version | null
 }

--- a/src/core/state/Variables/Items/V4/PlaydeckVariableItemsV4.ts
+++ b/src/core/state/Variables/Items/V4/PlaydeckVariableItemsV4.ts
@@ -107,6 +107,30 @@ const variableItemsV40b00: PlaydeckVariableItem[] = [
 		getVariableDefinition: (channel?: number): CompanionVariableDefinition | null => {
 			if (channel === undefined) return null
 			return {
+				variableId: `channel_${channel + 1}_canplay_error`,
+				name: `Indicates that at least one track cannot be played on channel channel #${channel + 1}`,
+			}
+		},
+		getFromData(
+			data: { data?: PlaydeckDataTypeV4; current?: PlaydeckValuesV4 },
+			channel?: number,
+		): CompanionVariableValue | undefined {
+			if (channel === undefined) return
+			if (!(data?.data && data.current)) return
+			const dataValues = data.data.getValues()
+			if (!dataValues?.channel) return
+			const channelData = dataValues.channel[channel]
+			if (!channelData || !channelData.block) return
+			return channelData.block.some((block) => block.clip && block.clip.some((clip) => clip.canPlay === false))
+		},
+		channel: true,
+		version: '4.1b11',
+		deprecated: null,
+	},
+	{
+		getVariableDefinition: (channel?: number): CompanionVariableDefinition | null => {
+			if (channel === undefined) return null
+			return {
 				variableId: `channel_${channel + 1}_tally`,
 				name: `Tally state of channel #${channel + 1}`,
 			}

--- a/src/core/state/Variables/Items/V4/PlaydeckVariableItemsV4.ts
+++ b/src/core/state/Variables/Items/V4/PlaydeckVariableItemsV4.ts
@@ -696,7 +696,7 @@ const variableItemsV40b00: PlaydeckVariableItem[] = [
 			if (channel === undefined) return null
 			return {
 				variableId: `channel_${channel + 1}_selected_clip_number`,
-				name: `Selected clip name on channel #${channel + 1}`,
+				name: `Selected clip number (in block) on channel #${channel + 1}`,
 			}
 		},
 		getFromData(
@@ -722,7 +722,7 @@ const variableItemsV40b00: PlaydeckVariableItem[] = [
 			if (channel === undefined) return null
 			return {
 				variableId: `channel_${channel + 1}_selected_clip_canplay`,
-				name: `Selected clip name on channel #${channel + 1}`,
+				name: `Selected clip ability to play on channel #${channel + 1}`,
 			}
 		},
 		getFromData(
@@ -748,7 +748,7 @@ const variableItemsV40b00: PlaydeckVariableItem[] = [
 			if (channel === undefined) return null
 			return {
 				variableId: `channel_${channel + 1}_selected_clip_block`,
-				name: `Selected clip name on channel #${channel + 1}`,
+				name: `Selected clip parent block number on channel #${channel + 1}`,
 			}
 		},
 		getFromData(
@@ -777,7 +777,7 @@ const variableItemsV40b00: PlaydeckVariableItem[] = [
 			if (channel === undefined) return null
 			return {
 				variableId: `channel_${channel + 1}_selected_clip_block_name`,
-				name: `Selected clip name on channel #${channel + 1}`,
+				name: `Selected clip parent block name on channel #${channel + 1}`,
 			}
 		},
 		getFromData(
@@ -832,7 +832,7 @@ const variableItemsV40b00: PlaydeckVariableItem[] = [
 			if (channel === undefined) return null
 			return {
 				variableId: `channel_${channel + 1}_selected_clip_filetype`,
-				name: `Selected clip type on channel #${channel + 1}`,
+				name: `Selected clip file type on channel #${channel + 1}`,
 			}
 		},
 		getFromData(

--- a/src/core/state/Variables/Items/V4/PlaydeckVariableItemsV4.ts
+++ b/src/core/state/Variables/Items/V4/PlaydeckVariableItemsV4.ts
@@ -609,6 +609,66 @@ const variableItemsV40b00: PlaydeckVariableItem[] = [
 		getVariableDefinition: (channel?: number): CompanionVariableDefinition | null => {
 			if (channel === undefined) return null
 			return {
+				variableId: `channel_${channel + 1}_block_1_name`,
+				name: `Name of block #1 in channel #${channel + 1}`,
+			}
+		},
+		getFromData(
+			data: { data?: PlaydeckDataTypeV4; current?: PlaydeckValuesV4 },
+			channel?: number,
+		): CompanionVariableValue | undefined {
+			if (channel === undefined) return
+			if (!(data?.data && data.current)) return
+			const dataValues = data.data.getValues()
+			if (!dataValues?.channel) return
+			const channelData = dataValues.channel[channel]
+			if (!channelData) return
+			if (!channelData.block) return
+			const blockData = channelData.block[0]
+			if (!blockData) return
+			const firstBlockName = blockData.name
+			return firstBlockName
+		},
+		channel: true,
+		version: '4.1b11',
+		deprecated: null,
+	},
+	{
+		getVariableDefinition: (channel?: number): CompanionVariableDefinition | null => {
+			if (channel === undefined) return null
+			return {
+				variableId: `channel_${channel + 1}_block_1_clipname`,
+				name: `Name of first clip in block #1 in channel #${channel + 1}`,
+			}
+		},
+		getFromData(
+			data: { data?: PlaydeckDataTypeV4; current?: PlaydeckValuesV4 },
+			channel?: number,
+		): CompanionVariableValue | undefined {
+			if (channel === undefined) return
+			if (!(data?.data && data.current)) return
+			const dataValues = data.data.getValues()
+			if (!dataValues?.channel) return
+			const channelData = dataValues.channel[channel]
+			if (!channelData) return
+			if (!channelData.block) return
+			const blockData = channelData.block[0]
+			if (!blockData) return
+			const clipData = blockData.clip
+			if (!clipData) return
+			const firstClipData = clipData[0]
+			if (!firstClipData) return
+			const firstBlockName = firstClipData.name
+			return firstBlockName
+		},
+		channel: true,
+		version: '4.1b11',
+		deprecated: null,
+	},
+	{
+		getVariableDefinition: (channel?: number): CompanionVariableDefinition | null => {
+			if (channel === undefined) return null
+			return {
 				variableId: `channel_${channel + 1}_selected_clip_name`,
 				name: `Selected clip name on channel #${channel + 1}`,
 			}

--- a/src/core/state/Variables/Items/V4/PlaydeckVariableItemsV4.ts
+++ b/src/core/state/Variables/Items/V4/PlaydeckVariableItemsV4.ts
@@ -183,27 +183,6 @@ const variableItemsV40b00: PlaydeckVariableItem[] = [
 		version: '4.1b11',
 		deprecated: null,
 	},
-	{
-		getVariableDefinition: (channel?: number): CompanionVariableDefinition | null => {
-			if (channel === undefined) return null
-			return {
-				variableId: `channel_${channel + 1}_selected_id`,
-				name: `Selected ID on channel #${channel + 1}`,
-			}
-		},
-		getCurrentValue: (current: PlaydeckValuesV4, channel?: number): CompanionVariableValue | undefined | null => {
-			if (channel !== undefined && current.channel !== null) {
-				const chan = current.channel[channel]
-				if (chan === undefined) return null
-				if (chan.selectedID === undefined) return null
-				return chan.selectedID
-			}
-			return
-		},
-		channel: true,
-		version: '4.2b9',
-		deprecated: null,
-	},
 	////
 	{
 		getVariableDefinition: (channel?: number): CompanionVariableDefinition | null => {
@@ -665,6 +644,93 @@ const variableItemsV40b00: PlaydeckVariableItem[] = [
 		version: '4.1b11',
 		deprecated: null,
 	},
+]
+
+const variableItemsV41b16: PlaydeckVariableItem[] = [
+	{
+		getVariableDefinition: (channel?: number): CompanionVariableDefinition | null => {
+			if (channel === undefined) return null
+			return {
+				variableId: `channel_${channel + 1}_state`,
+				name: `Ready state of channel #${channel + 1}`,
+			}
+		},
+		getCurrentValue: (current: PlaydeckValuesV41b16, channel?: number): CompanionVariableValue | undefined | null => {
+			if (channel !== undefined && current.channel !== null) {
+				const chan = current.channel[channel]
+				if (chan === undefined) return null
+				if (!current.states) return chan.channelState
+				return current.states.channel[channel]
+			}
+			return
+		},
+		channel: true,
+		version: '4.1b16',
+		deprecated: null,
+	},
+	...getOtherStates(),
+]
+
+function getOtherStates(): PlaydeckVariableItem[] {
+	const stateableObjectsWithCapacity = {
+		channel: 8,
+		output: 8,
+		input: 12,
+		stream: 15,
+		director: 4,
+		recording: 4,
+	}
+	const result = []
+	for (const [stateableObject, capacity] of Object.entries(stateableObjectsWithCapacity)) {
+		if (stateableObject === 'channel') continue
+
+		for (let i = 0; i < capacity; i++) {
+			const varItem: PlaydeckVariableItem = {
+				getVariableDefinition: (): CompanionVariableDefinition | null => {
+					return {
+						variableId: `${stateableObject}_${i + 1}_state`,
+						name: `Ready state of ${stateableObject.toLowerCase() == StateableTargets.Output.toLowerCase() ? `channel ${stateableObject}` : stateableObject} #${i + 1}`,
+					}
+				},
+				getCurrentValue: (current: PlaydeckValuesV41b16): CompanionVariableValue | undefined | null => {
+					const states = current.states
+					if (!states) return null
+					const statesKey = stateableObject as keyof typeof states
+					if (!states[statesKey]) return null
+					return states[statesKey][i]
+				},
+				channel: false,
+				version: '4.1b16',
+				deprecated: null,
+			}
+			result.push(varItem)
+		}
+	}
+	return result
+}
+
+const variableItemsV42b19: PlaydeckVariableItem[] = [
+	{
+		getVariableDefinition: (channel?: number): CompanionVariableDefinition | null => {
+			if (channel === undefined) return null
+			return {
+				variableId: `channel_${channel + 1}_selected_id`,
+				name: `Selected ID on channel #${channel + 1}`,
+			}
+		},
+		getCurrentValue: (current: PlaydeckValuesV4, channel?: number): CompanionVariableValue | undefined | null => {
+			if (channel !== undefined && current.channel !== null) {
+				const chan = current.channel[channel]
+				if (chan === undefined) return null
+				if (chan.selectedID === undefined) return null
+				return chan.selectedID
+			}
+			return
+		},
+		channel: true,
+		version: '4.2b9',
+		deprecated: null,
+	},
 	{
 		getVariableDefinition: (channel?: number): CompanionVariableDefinition | null => {
 			if (channel === undefined) return null
@@ -854,68 +920,8 @@ const variableItemsV40b00: PlaydeckVariableItem[] = [
 		deprecated: null,
 	},
 ]
-
-const variableItemsV41b16: PlaydeckVariableItem[] = [
-	{
-		getVariableDefinition: (channel?: number): CompanionVariableDefinition | null => {
-			if (channel === undefined) return null
-			return {
-				variableId: `channel_${channel + 1}_state`,
-				name: `Ready state of channel #${channel + 1}`,
-			}
-		},
-		getCurrentValue: (current: PlaydeckValuesV41b16, channel?: number): CompanionVariableValue | undefined | null => {
-			if (channel !== undefined && current.channel !== null) {
-				const chan = current.channel[channel]
-				if (chan === undefined) return null
-				if (!current.states) return chan.channelState
-				return current.states.channel[channel]
-			}
-			return
-		},
-		channel: true,
-		version: '4.1b16',
-		deprecated: null,
-	},
-	...getOtherStates(),
+export const variableItemsV4: PlaydeckVariableItem[] = [
+	...variableItemsV40b00,
+	...variableItemsV41b16,
+	...variableItemsV42b19,
 ]
-
-function getOtherStates(): PlaydeckVariableItem[] {
-	const stateableObjectsWithCapacity = {
-		channel: 8,
-		output: 8,
-		input: 12,
-		stream: 15,
-		director: 4,
-		recording: 4,
-	}
-	const result = []
-	for (const [stateableObject, capacity] of Object.entries(stateableObjectsWithCapacity)) {
-		if (stateableObject === 'channel') continue
-
-		for (let i = 0; i < capacity; i++) {
-			const varItem: PlaydeckVariableItem = {
-				getVariableDefinition: (): CompanionVariableDefinition | null => {
-					return {
-						variableId: `${stateableObject}_${i + 1}_state`,
-						name: `Ready state of ${stateableObject.toLowerCase() == StateableTargets.Output.toLowerCase() ? `channel ${stateableObject}` : stateableObject} #${i + 1}`,
-					}
-				},
-				getCurrentValue: (current: PlaydeckValuesV41b16): CompanionVariableValue | undefined | null => {
-					const states = current.states
-					if (!states) return null
-					const statesKey = stateableObject as keyof typeof states
-					if (!states[statesKey]) return null
-					return states[statesKey][i]
-				},
-				channel: false,
-				version: '4.1b16',
-				deprecated: null,
-			}
-			result.push(varItem)
-		}
-	}
-	return result
-}
-
-export const variableItemsV4: PlaydeckVariableItem[] = [...variableItemsV40b00, ...variableItemsV41b16]

--- a/src/core/state/Variables/Items/V4/PlaydeckVariableItemsV4.ts
+++ b/src/core/state/Variables/Items/V4/PlaydeckVariableItemsV4.ts
@@ -249,6 +249,26 @@ const variableItemsV40b00: PlaydeckVariableItem[] = [
 		getVariableDefinition: (channel?: number): CompanionVariableDefinition | null => {
 			if (channel === undefined) return null
 			return {
+				variableId: `channel_${channel + 1}_clip_number`,
+				name: `Current clip number on channel #${channel + 1}`,
+			}
+		},
+		getCurrentValue: (current: PlaydeckValuesV4, channel?: number): CompanionVariableValue | undefined | null => {
+			if (channel !== undefined && current.channel !== null) {
+				const chan = current.channel[channel]
+				if (chan === undefined) return null
+				return chan.clipNumber
+			}
+			return
+		},
+		channel: true,
+		version: '4.1b11',
+		deprecated: null,
+	},
+	{
+		getVariableDefinition: (channel?: number): CompanionVariableDefinition | null => {
+			if (channel === undefined) return null
+			return {
 				variableId: `channel_${channel + 1}_clip_position`,
 				name: `Current clip playhead position on channel #${channel + 1}`,
 			}
@@ -379,6 +399,26 @@ const variableItemsV40b00: PlaydeckVariableItem[] = [
 				const chan = current.channel[channel]
 				if (chan === undefined) return null
 				return chan.blockID
+			}
+			return
+		},
+		channel: true,
+		version: '4.1b11',
+		deprecated: null,
+	},
+	{
+		getVariableDefinition: (channel?: number): CompanionVariableDefinition | null => {
+			if (channel === undefined) return null
+			return {
+				variableId: `channel_${channel + 1}_block_number`,
+				name: `Current block Number on channel #${channel + 1}`,
+			}
+		},
+		getCurrentValue: (current: PlaydeckValuesV4, channel?: number): CompanionVariableValue | undefined | null => {
+			if (channel !== undefined && current.channel !== null) {
+				const chan = current.channel[channel]
+				if (chan === undefined) return null
+				return chan.blockNumber
 			}
 			return
 		},

--- a/src/core/state/Variables/Items/V4/PlaydeckVariableItemsV4.ts
+++ b/src/core/state/Variables/Items/V4/PlaydeckVariableItemsV4.ts
@@ -812,7 +812,7 @@ const variableItemsV42b19: PlaydeckVariableItem[] = [
 			if (channel === undefined) return null
 			return {
 				variableId: `channel_${channel + 1}_selected_clip_canplay`,
-				name: `Selected clip ability to play on channel #${channel + 1}`,
+				name: `Indicates whether the selected clip can be played on channel #${channel + 1}`,
 			}
 		},
 		getFromData(

--- a/src/core/state/Variables/Items/V4/PlaydeckVariableItemsV4.ts
+++ b/src/core/state/Variables/Items/V4/PlaydeckVariableItemsV4.ts
@@ -207,6 +207,32 @@ const variableItemsV40b00: PlaydeckVariableItem[] = [
 		version: '4.1b11',
 		deprecated: null,
 	},
+	{
+		getVariableDefinition: (channel?: number): CompanionVariableDefinition | null => {
+			if (channel === undefined) return null
+			return {
+				variableId: `channel_${channel + 1}_block_clip_count`,
+				name: `Amount of clips in current block in channel #${channel + 1}`,
+			}
+		},
+		getFromData(
+			data: { data?: PlaydeckDataTypeV4; current?: PlaydeckValuesV4 },
+			channel?: number,
+		): CompanionVariableValue | undefined {
+			if (channel === undefined) return
+			if (!(data?.data && data.current)) return
+			if (data.current.channel === null) return
+			if (data.current.channel[channel] === undefined) return
+			const id = data.current.channel[channel].blockID
+			if (id === undefined) return
+			const block = data.data.getItemByID(id) as PlaydeckBlockData
+			if (block === null) return
+			return block.clipCount
+		},
+		channel: true,
+		version: '4.1b11',
+		deprecated: null,
+	},
 	////
 	{
 		getVariableDefinition: (channel?: number): CompanionVariableDefinition | null => {

--- a/src/core/state/Variables/Items/V4/PlaydeckVariableItemsV4.ts
+++ b/src/core/state/Variables/Items/V4/PlaydeckVariableItemsV4.ts
@@ -108,7 +108,7 @@ const variableItemsV40b00: PlaydeckVariableItem[] = [
 			if (channel === undefined) return null
 			return {
 				variableId: `channel_${channel + 1}_canplay_error`,
-				name: `Indicates that at least one track cannot be played on channel channel #${channel + 1}`,
+				name: `Indicates that at least one track cannot be played on channel #${channel + 1}`,
 			}
 		},
 		getFromData(

--- a/src/core/state/Variables/Items/V4/PlaydeckVariableItemsV4.ts
+++ b/src/core/state/Variables/Items/V4/PlaydeckVariableItemsV4.ts
@@ -635,16 +635,17 @@ const variableItemsV40b00: PlaydeckVariableItem[] = [
 		deprecated: null,
 	},
 	{
-		getVariableDefinition: (channel?: number): CompanionVariableDefinition | null => {
+		getVariableDefinition: (channel?: number, block: number = 0): CompanionVariableDefinition | null => {
 			if (channel === undefined) return null
 			return {
-				variableId: `channel_${channel + 1}_block_1_name`,
-				name: `Name of block #1 in channel #${channel + 1}`,
+				variableId: `channel_${channel + 1}_block_${block + 1}_name`,
+				name: `Name of block #${block + 1} in channel #${channel + 1}`,
 			}
 		},
 		getFromData(
 			data: { data?: PlaydeckDataTypeV4; current?: PlaydeckValuesV4 },
 			channel?: number,
+			block: number = 0,
 		): CompanionVariableValue | undefined {
 			if (channel === undefined) return
 			if (!(data?.data && data.current)) return
@@ -653,26 +654,28 @@ const variableItemsV40b00: PlaydeckVariableItem[] = [
 			const channelData = dataValues.channel[channel]
 			if (!channelData) return
 			if (!channelData.block) return
-			const blockData = channelData.block[0]
+			const blockData = channelData.block[block]
 			if (!blockData) return
 			const firstBlockName = blockData.name
 			return firstBlockName
 		},
 		channel: true,
+		block: true,
 		version: '4.1b11',
 		deprecated: null,
 	},
 	{
-		getVariableDefinition: (channel?: number): CompanionVariableDefinition | null => {
+		getVariableDefinition: (channel?: number, block: number = 0): CompanionVariableDefinition | null => {
 			if (channel === undefined) return null
 			return {
-				variableId: `channel_${channel + 1}_block_1_clipname`,
-				name: `Name of first clip in block #1 in channel #${channel + 1}`,
+				variableId: `channel_${channel + 1}_block_${block + 1}_clipname`,
+				name: `Name of first clip in block #${block + 1} in channel #${channel + 1}`,
 			}
 		},
 		getFromData(
 			data: { data?: PlaydeckDataTypeV4; current?: PlaydeckValuesV4 },
 			channel?: number,
+			block: number = 0,
 		): CompanionVariableValue | undefined {
 			if (channel === undefined) return
 			if (!(data?.data && data.current)) return
@@ -681,7 +684,7 @@ const variableItemsV40b00: PlaydeckVariableItem[] = [
 			const channelData = dataValues.channel[channel]
 			if (!channelData) return
 			if (!channelData.block) return
-			const blockData = channelData.block[0]
+			const blockData = channelData.block[block]
 			if (!blockData) return
 			const clipData = blockData.clip
 			if (!clipData) return
@@ -691,6 +694,7 @@ const variableItemsV40b00: PlaydeckVariableItem[] = [
 			return firstBlockName
 		},
 		channel: true,
+		block: true,
 		version: '4.1b11',
 		deprecated: null,
 	},

--- a/src/core/state/Variables/Items/V4/PlaydeckVariableItemsV4.ts
+++ b/src/core/state/Variables/Items/V4/PlaydeckVariableItemsV4.ts
@@ -695,6 +695,116 @@ const variableItemsV40b00: PlaydeckVariableItem[] = [
 		getVariableDefinition: (channel?: number): CompanionVariableDefinition | null => {
 			if (channel === undefined) return null
 			return {
+				variableId: `channel_${channel + 1}_selected_clip_number`,
+				name: `Selected clip name on channel #${channel + 1}`,
+			}
+		},
+		getFromData(
+			data: { data?: PlaydeckDataTypeV4; current?: PlaydeckValuesV4 },
+			channel?: number,
+		): CompanionVariableValue | undefined {
+			if (channel === undefined) return
+			if (!(data?.data && data.current)) return
+			if (data.current.channel === null) return
+			if (data.current.channel[channel] === undefined) return
+			const id = data.current.channel[channel].selectedID
+			if (id === undefined) return
+			const clip = data.data.getItemByID(id) as PlaydeckClipData
+			if (clip === null) return
+			return clip.number
+		},
+		channel: true,
+		version: '4.2b9',
+		deprecated: null,
+	},
+	{
+		getVariableDefinition: (channel?: number): CompanionVariableDefinition | null => {
+			if (channel === undefined) return null
+			return {
+				variableId: `channel_${channel + 1}_selected_clip_canplay`,
+				name: `Selected clip name on channel #${channel + 1}`,
+			}
+		},
+		getFromData(
+			data: { data?: PlaydeckDataTypeV4; current?: PlaydeckValuesV4 },
+			channel?: number,
+		): CompanionVariableValue | undefined {
+			if (channel === undefined) return
+			if (!(data?.data && data.current)) return
+			if (data.current.channel === null) return
+			if (data.current.channel[channel] === undefined) return
+			const id = data.current.channel[channel].selectedID
+			if (id === undefined) return
+			const clip = data.data.getItemByID(id) as PlaydeckClipData
+			if (clip === null) return
+			return clip.canPlay
+		},
+		channel: true,
+		version: '4.2b9',
+		deprecated: null,
+	},
+	{
+		getVariableDefinition: (channel?: number): CompanionVariableDefinition | null => {
+			if (channel === undefined) return null
+			return {
+				variableId: `channel_${channel + 1}_selected_clip_block`,
+				name: `Selected clip name on channel #${channel + 1}`,
+			}
+		},
+		getFromData(
+			data: { data?: PlaydeckDataTypeV4; current?: PlaydeckValuesV4 },
+			channel?: number,
+		): CompanionVariableValue | undefined {
+			if (channel === undefined) return
+			if (!(data?.data && data.current)) return
+			if (data.current.channel === null) return
+			if (data.current.channel[channel] === undefined) return
+			const id = data.current.channel[channel].selectedID
+			if (id === undefined) return
+			const clip = data.data.getItemByID(id) as PlaydeckClipData
+			if (clip === null) return
+			if (clip.parentID === undefined) return
+			const parentBlock = data.data.getItemByID(clip.parentID) as PlaydeckBlockData
+			if (parentBlock === null) return
+			return parentBlock.number
+		},
+		channel: true,
+		version: '4.2b9',
+		deprecated: null,
+	},
+	{
+		getVariableDefinition: (channel?: number): CompanionVariableDefinition | null => {
+			if (channel === undefined) return null
+			return {
+				variableId: `channel_${channel + 1}_selected_clip_block_name`,
+				name: `Selected clip name on channel #${channel + 1}`,
+			}
+		},
+		getFromData(
+			data: { data?: PlaydeckDataTypeV4; current?: PlaydeckValuesV4 },
+			channel?: number,
+		): CompanionVariableValue | undefined {
+			if (channel === undefined) return
+			if (!(data?.data && data.current)) return
+			if (data.current.channel === null) return
+			if (data.current.channel[channel] === undefined) return
+			const id = data.current.channel[channel].selectedID
+			if (id === undefined) return
+			const clip = data.data.getItemByID(id) as PlaydeckClipData
+			if (clip === null) return
+			if (clip.parentID === undefined) return
+			const parentBlock = data.data.getItemByID(clip.parentID) as PlaydeckBlockData
+			if (parentBlock === null) return
+			return parentBlock.name
+		},
+		channel: true,
+		version: '4.2b9',
+		deprecated: null,
+	},
+	{
+		getVariableDefinition: (channel?: number): CompanionVariableDefinition | null => {
+			if (channel === undefined) return null
+			return {
 				variableId: `channel_${channel + 1}_selected_clip_type`,
 				name: `Selected clip type on channel #${channel + 1}`,
 			}

--- a/src/core/state/Variables/PlaydeckVariables.ts
+++ b/src/core/state/Variables/PlaydeckVariables.ts
@@ -30,7 +30,14 @@ export class PlaydeckVariables {
 				if (channelCount) {
 					for (let i = 0; i < channelCount; i++) {
 						newVar.channel = i
-						this.#addVariable(this.#covertToVariable(newVar))
+						if (newVar.block) {
+							for (let b = 0; b < 42; b++) {
+								newVar.block = b
+								this.#addVariable(this.#covertToVariable(newVar))
+							}
+						} else {
+							this.#addVariable(this.#covertToVariable(newVar))
+						}
 					}
 				}
 			} else {
@@ -40,14 +47,16 @@ export class PlaydeckVariables {
 	}
 	#covertToVariable(variableItem: PlaydeckVariableItem): PlaydeckVariable {
 		const channel = typeof variableItem.channel === 'number' ? variableItem.channel : undefined
+		const block = typeof variableItem.block === 'number' ? variableItem.block : undefined
 		return {
-			variableDefinition: variableItem.getVariableDefinition(channel),
+			variableDefinition: variableItem.getVariableDefinition(channel, block),
 			value: undefined,
 			getVariableDefinition: variableItem.getVariableDefinition,
 			getCurrentValue: variableItem.getCurrentValue,
 			getFromData: variableItem.getFromData,
 			getValueFromEvent: variableItem.getValueFromEvent,
 			channel: variableItem.channel,
+			block: variableItem.block,
 			version: variableItem.version,
 			deprecated: variableItem.deprecated,
 		}
@@ -92,12 +101,13 @@ export class PlaydeckVariables {
 			}
 			if (data === undefined || data === null) return
 			const сhannelIndex = typeof variable.channel === 'number' ? variable.channel : undefined
+			const blockIndex = typeof variable.block === 'number' ? variable.block : undefined
 			const method =
 				variable[methodName] && typeof variable[methodName] === 'function' ? variable[methodName] : undefined
 			if (method === undefined) return
 			let value = null
 			try {
-				value = method(data, сhannelIndex)
+				value = method(data, сhannelIndex, blockIndex)
 			} catch (e) {
 				if (e instanceof Error) {
 					this.#log(

--- a/src/core/version/PlaydeckVersion.ts
+++ b/src/core/version/PlaydeckVersion.ts
@@ -10,6 +10,8 @@ export class PlaydeckVersion {
 	static #FIRST_TCP_EVENTS: Version = `3.5b3`
 	static #FIRST_WS_CONNECTION: Version = `3.6b18`
 	static configVersions = [
+		{ id: '4.3b3', label: '4.3b3' },
+		{ id: '4.3b2', label: '4.3b2' },
 		{ id: '4.2b9', label: '4.2b9' },
 		{ id: '4.1b16', label: '4.1b16' },
 		{ id: '4.1b14', label: '4.1b14' },

--- a/src/upgrades/PlaydeckUpgrades.ts
+++ b/src/upgrades/PlaydeckUpgrades.ts
@@ -1,5 +1,5 @@
 import type { CompanionStaticUpgradeScript } from '@companion-module/base'
-import { PlaydeckConfig } from '../config/PlaydeckConfig'
+import { PlaydeckConfig } from '../config/PlaydeckConfig.js'
 
 export const UpgradeScripts: CompanionStaticUpgradeScript<PlaydeckConfig>[] = [
 	/*


### PR DESCRIPTION
## Changelog

### Added

- New command and actions for **v4.3b3**:
  - POSITION MARKER
- New preset for the new command
- New `END` event in `Check playback state`: 
Returns `true`, when the clip has finished playing, and false after any playback action following the clip’s end
- Support of local variables in text fields
- Added new variables:

  - `$(Playdeck:channel_X_clip/block_number)`  
    Current clip/block number on channel #X
  - `$(Playdeck:channel_X_block_Y_name/clipname)`  
    Name of block/first clip in block #Y in channel #X
  - `$(Playdeck:channel_X_block_clip_count)`  
    Amount of clips in current block in channel #X
  - `$(Playdeck:channel_X_canplay_error)`  
    Indicates that at least one track cannot be played on channel channel #X

### Fixed

- Fixed some typos
